### PR TITLE
Model configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2023-02-01
+
+### Added 
+- Added ability to pass keyword arguments to model class \_\_init\_\_() method from the configuration file.
+- Added lock to StatusManager singleton \_\_new\_\_() method to prevent race conditions.
+
+### Removed
+- Removed "qualified_name" key from model configuration in configuration file, this configuration option is not needed.
+
 ## [0.4.1] - 2022-12-21
 
 ### Added 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, schmidtbri
+Copyright (c) 2023, schmidtbri
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ interface around model prediction logic that allows the rest_model_service packa
 it. Some examples of how to create MLModel classes for your model can be found 
 [here](https://schmidtbri.github.io/ml-base/basic/).
 
-You can then set up a configuration file that points at the model class of the model you want to predict. The 
+You can then set up a configuration file that points at the model class of the model you want to host. The 
 configuration file should look like this:
 
 ```yaml

--- a/examples/decorators_config.yaml
+++ b/examples/decorators_config.yaml
@@ -1,7 +1,6 @@
 service_title: REST Model Service With Decorators
 models:
-  - qualified_name: iris_model
-    class_path: tests.mocks.IrisModel
+  - class_path: tests.mocks.IrisModel
     create_endpoint: true
     decorators:
       - class_path: tests.mocks.PredictionIDDecorator

--- a/examples/logging_config.yaml
+++ b/examples/logging_config.yaml
@@ -1,7 +1,6 @@
 service_title: REST Model Service With Logging
 models:
-  - qualified_name: iris_model
-    class_path: tests.mocks.IrisModel
+  - class_path: tests.mocks.IrisModel
     create_endpoint: true
 logging:
     version: 1

--- a/examples/rest_config.yaml
+++ b/examples/rest_config.yaml
@@ -1,5 +1,4 @@
 service_title: REST Model Service
 models:
-  - qualified_name: iris_model
-    class_path: tests.mocks.IrisModel
+  - class_path: tests.mocks.IrisModel
     create_endpoint: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ anyio==3.6.2
     # via starlette
 click==8.1.3
     # via uvicorn
-fastapi==0.88.0
+fastapi==0.89.1
     # via -r requirements.in
 h11==0.14.0
     # via uvicorn
@@ -16,7 +16,7 @@ idna==3.4
     # via anyio
 ml-base==0.2.1
     # via -r requirements.in
-pydantic==1.10.2
+pydantic==1.10.4
     # via
     #   fastapi
     #   ml-base

--- a/rest_model_service/configuration.py
+++ b/rest_model_service/configuration.py
@@ -7,19 +7,19 @@ class ModelDecorator(BaseModel):
     """Settings for a decorator for a model instance in the service."""
 
     class_path: str = Field(description="Class path of the decorator class.")
-    configuration: Optional[Dict[Any, Any]] = Field(description="Configuration to initialize decorator instance.")
+    configuration: Optional[Dict[str, Any]] = Field(description="Configuration to initialize decorator instance.")
 
 
 class Model(BaseModel):
     """Settings for a single model in the service."""
 
-    qualified_name: str = Field(description="Qualified name of the model.")
     class_path: str = Field(description="Class path of the model class.")
     create_endpoint: bool = Field(description="Whether or not to create an endpoint for the model.")
     decorators: Optional[List[ModelDecorator]] = Field(description="List of decorators to attach to model.")
+    configuration: Optional[Dict[str, Any]] = Field(description="Configuration to initialize model instance.")
 
 
-class Configuration(BaseModel):
+class ServiceConfiguration(BaseModel):
     """Configuration for the service."""
 
     service_title: str = "RESTful Model Service"

--- a/rest_model_service/generate_openapi.py
+++ b/rest_model_service/generate_openapi.py
@@ -6,7 +6,7 @@ import argparse
 import yaml
 
 from rest_model_service.helpers import create_app
-from rest_model_service.configuration import Configuration
+from rest_model_service.configuration import ServiceConfiguration
 
 
 def main() -> None:
@@ -21,7 +21,7 @@ def main() -> None:
     try:
         with open(args.configuration_file, "r") as file:
             configuration_dict = yaml.full_load(file)
-        configuration = Configuration(**configuration_dict)
+        configuration = ServiceConfiguration(**configuration_dict)
 
         # create application object, waiting for model creation to finish in order to have all the model endpoints in
         # the OpenAPI document

--- a/rest_model_service/main.py
+++ b/rest_model_service/main.py
@@ -4,7 +4,7 @@ from os import path
 import logging.config
 import yaml
 
-from rest_model_service.configuration import Configuration
+from rest_model_service.configuration import ServiceConfiguration
 from rest_model_service.helpers import create_app
 
 
@@ -22,8 +22,8 @@ else:
 if path.exists(file_path) and path.isfile(file_path):
     with open(file_path) as file:
         configuration_dict = yaml.full_load(file)
-    configuration = Configuration(**configuration_dict)
+    configuration = ServiceConfiguration(**configuration_dict)
     app = create_app(configuration, wait_for_model_creation=False)
 else:
-    # if there is no configuration file, or it is not found, then raise a warning
+    # if there is no configuration file, or it is not found, then raise an exception
     raise ValueError("Could not find configuration file '{}', service has no models loaded.".format(file_path))

--- a/rest_model_service/status_manager.py
+++ b/rest_model_service/status_manager.py
@@ -7,6 +7,7 @@ from rest_model_service.schemas import HealthStatus, ReadinessStatus, StartupSta
 
 class StatusManager(object):
     """Health status manager singleton."""
+
     _lock = Lock()
 
     def __new__(cls, *args: Tuple, **kwargs: Dict):  # noqa: D102, ANN101, ANN204

--- a/rest_model_service/status_manager.py
+++ b/rest_model_service/status_manager.py
@@ -1,16 +1,20 @@
 """Health status manager that holds health status information for the application."""
 from typing import Tuple, Dict
+from threading import Lock
+
 from rest_model_service.schemas import HealthStatus, ReadinessStatus, StartupStatus
 
 
 class StatusManager(object):
     """Health status manager singleton."""
+    _lock = Lock()
 
     def __new__(cls, *args: Tuple, **kwargs: Dict):  # noqa: D102, ANN101, ANN204
         """Create new StatusManager instance, after instance is first created it will always be returned."""
         if not hasattr(cls, "_instance"):
-            cls._instance = super(StatusManager, cls).__new__(cls, *args, **kwargs)
-            cls._instance._is_initialized = False
+            with cls._lock:
+                cls._instance = super(StatusManager, cls).__new__(cls, *args, **kwargs)
+                cls._instance._is_initialized = False
         return cls._instance
 
     def __init__(self) -> None:  # noqa: ANN101

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,10 @@ setup(name="rest_model_service",
             ]
       },
       classifiers=[
-          "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
           "Programming Language :: Python :: 3.9",
           "Programming Language :: Python :: 3.10",
+          "Programming Language :: Python :: 3.11",
           "Intended Audience :: Developers",
           "Operating System :: OS Independent"
       ],
@@ -48,5 +47,5 @@ setup(name="rest_model_service",
           "Tracker": "https://github.com/schmidtbri/rest-model-service/issues"
       },
       keywords=[
-          "machine learning", "REST", "service"
+          "machine learning", "REST", "service", "model deployment"
       ])

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -20,7 +20,7 @@ certifi==2022.12.7
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -28,31 +28,31 @@ click==8.1.3
     #   uvicorn
 colorama==0.4.6
     # via radon
-coverage==7.0.0
+coverage==7.1.0
     # via
     #   -r test_requirements.in
     #   coverage-badge
 coverage-badge==1.1.0
     # via -r test_requirements.in
-dnspython==2.2.1
+dnspython==2.3.0
     # via email-validator
 dparse==0.6.2
     # via safety
-email-validator==1.3.0
+email-validator==1.3.1
     # via fastapi
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
-fastapi[all]==0.88.0
+fastapi[all]==0.89.1
     # via -r test_requirements.in
 flake8==6.0.0
     # via flake8-annotations
-flake8-annotations==2.9.1
+flake8-annotations==3.0.0
     # via -r test_requirements.in
-future==0.18.2
+future==0.18.3
     # via radon
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.29
+gitpython==3.1.30
     # via bandit
 h11==0.14.0
     # via
@@ -62,7 +62,7 @@ httpcore==0.16.3
     # via httpx
 httptools==0.5.0
     # via uvicorn
-httpx==0.23.1
+httpx==0.23.3
     # via fastapi
 idna==3.4
     # via
@@ -70,7 +70,7 @@ idna==3.4
     #   email-validator
     #   requests
     #   rfc3986
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 itsdangerous==2.1.2
     # via fastapi
@@ -78,20 +78,20 @@ jinja2==3.1.2
     # via fastapi
 mando==0.6.4
     # via radon
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via
     #   flake8
     #   pylama
-orjson==3.8.3
+orjson==3.8.5
     # via fastapi
 packaging==21.3
     # via
     #   dparse
     #   pytest
     #   safety
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
 pluggy==1.0.0
     # via pytest
@@ -101,9 +101,9 @@ pycodestyle==2.10.0
     # via
     #   flake8
     #   pylama
-pydantic==1.10.2
+pydantic==1.10.4
     # via fastapi
-pydocstyle==6.1.1
+pydocstyle==6.3.0
     # via pylama
 pyflakes==3.0.1
     # via
@@ -113,7 +113,7 @@ pylama==8.4.1
     # via -r test_requirements.in
 pyparsing==3.0.9
     # via packaging
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   -r test_requirements.in
     #   pytest-html
@@ -122,7 +122,7 @@ pytest-html==3.2.0
     # via -r test_requirements.in
 pytest-metadata==2.0.4
     # via pytest-html
-python-dotenv==0.21.0
+python-dotenv==0.21.1
     # via uvicorn
 python-multipart==0.0.5
     # via fastapi
@@ -133,7 +133,7 @@ pyyaml==6.0
     #   uvicorn
 radon==5.1.0
     # via -r test_requirements.in
-requests==2.28.1
+requests==2.28.2
     # via safety
 rfc3986[idna2008]==1.5.0
     # via httpx
@@ -168,9 +168,9 @@ typing-extensions==4.4.0
     # via
     #   pydantic
     #   starlette
-ujson==5.6.0
+ujson==5.7.0
     # via fastapi
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 uvicorn[standard]==0.20.0
     # via fastapi

--- a/tests/integration/app_test.py
+++ b/tests/integration/app_test.py
@@ -7,15 +7,15 @@ from fastapi.testclient import TestClient
 os.chdir(Path(__file__).resolve().parent.parent.parent)
 
 from rest_model_service.helpers import create_app
-from rest_model_service.configuration import Model, Configuration
+from rest_model_service.configuration import Model, ServiceConfiguration
 
 
 class AppTests(unittest.TestCase):
 
     def test_service_endpoints_with_no_models(self):
         # arrange
-        app = create_app(Configuration(service_title="REST Model Service",
-                                       models=[]))
+        app = create_app(ServiceConfiguration(service_title="REST Model Service",
+                                              models=[]))
 
         # act
         with TestClient(app) as client:
@@ -32,11 +32,10 @@ class AppTests(unittest.TestCase):
 
     def test_health_endpoints_with_slow_loading_model(self):
         # arrange
-        configuration = Configuration(service_title="REST Model Service",
-                                      models=[
-                                          Model(qualified_name="slow_iris_model",
-                                                class_path="tests.mocks.SlowIrisModel",
-                                                create_endpoint=True)])
+        configuration = ServiceConfiguration(service_title="REST Model Service",
+                                             models=[
+                                                 Model(class_path="tests.mocks.SlowIrisModel",
+                                                       create_endpoint=True)])
 
         app = create_app(configuration)
 
@@ -68,11 +67,10 @@ class AppTests(unittest.TestCase):
 
     def test_health_endpoints_with_model_that_throws_exception_in_init(self):
         # arrange
-        configuration = Configuration(service_title="REST Model Service",
-                                      models=[
-                                          Model(qualified_name="iris_model_with_exception",
-                                                class_path="tests.mocks.IrisModelWithException",
-                                                create_endpoint=True)])
+        configuration = ServiceConfiguration(service_title="REST Model Service",
+                                             models=[
+                                                 Model(class_path="tests.mocks.IrisModelWithException",
+                                                       create_endpoint=True)])
         app = create_app(configuration)
 
         with TestClient(app) as client:

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -75,6 +75,22 @@ class IrisModelWithException(MLModel):
         return IrisModelOutput(species="Iris setosa")
 
 
+class IrisModelWithConfiguration(MLModel):
+    # accessing the package metadata
+    display_name = "Iris Model With Configuration"
+    qualified_name = "iris_model_with_configuration"
+    description = "Model for predicting the species of a flower based on its measurements, receives configuration in init."
+    version = "1.0.0"
+    input_schema = IrisModelInput
+    output_schema = IrisModelOutput
+
+    def __init__(self, **kwargs):
+        self.config = kwargs
+
+    def predict(self, data):
+        return IrisModelOutput(species="Iris setosa")
+
+
 # creating a mockup class to test with
 class SomeClass(object):
     pass

--- a/tests/unit/routes_test.py
+++ b/tests/unit/routes_test.py
@@ -11,7 +11,7 @@ from ml_base.ml_model import MLModelSchemaValidationException
 os.chdir(Path(__file__).resolve().parent.parent.parent)
 
 from rest_model_service.helpers import create_app
-from rest_model_service.configuration import Configuration, Model
+from rest_model_service.configuration import ServiceConfiguration, Model
 
 
 class RoutesTests(unittest.TestCase):
@@ -22,9 +22,8 @@ class RoutesTests(unittest.TestCase):
 
     def test_root(self):
         # arrange
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -37,9 +36,8 @@ class RoutesTests(unittest.TestCase):
 
     def test_get_models(self):
         # arrange
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -63,9 +61,8 @@ class RoutesTests(unittest.TestCase):
 
     def test_get_model_metadata(self):
         # arrange
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -89,9 +86,8 @@ class RoutesTests(unittest.TestCase):
         model_manager = ModelManager()
         model_manager.get_models = Mock(side_effect=Exception("Exception!"))
 
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -111,9 +107,8 @@ class RoutesTests(unittest.TestCase):
         model_manager = ModelManager()
         model_manager.get_model_metadata = Mock(side_effect=Exception("Exception!"))
 
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -130,9 +125,8 @@ class RoutesTests(unittest.TestCase):
 
     def test_prediction(self):
         # arrange
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -153,9 +147,8 @@ class RoutesTests(unittest.TestCase):
 
     def test_prediction_with_validation_exception_raised_in_model_predict_method(self):
         # arrange
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -181,9 +174,8 @@ class RoutesTests(unittest.TestCase):
 
     def test_prediction_with_exception_raised_in_model_predict_method(self):
         # arrange
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -209,9 +201,8 @@ class RoutesTests(unittest.TestCase):
 
     def test_prediction_with_bad_data(self):
         # arrange
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=True)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=True)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 
@@ -229,9 +220,8 @@ class RoutesTests(unittest.TestCase):
 
     def test_prediction_with_no_endpoint(self):
         # arrange
-        configuration = Configuration(models=[Model(qualified_name="iris_model",
-                                                    class_path="tests.mocks.IrisModel",
-                                                    create_endpoint=False)])
+        configuration = ServiceConfiguration(models=[Model(class_path="tests.mocks.IrisModel",
+                                                           create_endpoint=False)])
 
         app = create_app(configuration, wait_for_model_creation=True)
 


### PR DESCRIPTION
### Added 
- Added ability to pass keyword arguments to model class \_\_init\_\_() method from the configuration file.
- Added lock to StatusManager singleton \_\_new\_\_() method to prevent race conditions.

### Removed
- Removed "qualified_name" key from model configuration in configuration file, this configuration option is not needed.
